### PR TITLE
Fixed exceed date issue

### DIFF
--- a/src/main/java/com/artillexstudios/axcalendar/utils/CalendarUtils.java
+++ b/src/main/java/com/artillexstudios/axcalendar/utils/CalendarUtils.java
@@ -44,7 +44,17 @@ public class CalendarUtils {
     public static long getMilisUntilDay(int day) {
         final String monthStr = CONFIG.getString("month", "DECEMBER");
         Month month = monthStr.equalsIgnoreCase("AUTO") ? getZonedDateTime().getMonth() : Month.valueOf(monthStr);
-        final ZonedDateTime startOfTomorrow = getZonedDateTime().withMonth(month.getValue()).withDayOfMonth(day).toLocalDate().atStartOfDay(zoneId);
+        final ZonedDateTime startOfTomorrow;
+
+        if (month.minLength() < day) {
+            day = day - month.minLength();
+            int monthValue = month.getValue() == 12 ? 1 : month.getValue() + 1;
+            startOfTomorrow = getZonedDateTime().withMonth(monthValue).withDayOfMonth(day).toLocalDate().atStartOfDay(zoneId);
+        }
+        else {
+            startOfTomorrow = getZonedDateTime().withMonth(month.getValue()).withDayOfMonth(day).toLocalDate().atStartOfDay(zoneId);
+        }
+
         final Duration duration = Duration.between(getZonedDateTime(), startOfTomorrow);
         return duration.toMillis();
     }


### PR DESCRIPTION
This PR fixes exceed date issue. For example, if a user wants to use a fixed 31 day reward system, the plugin does not allow them to open the menu because of the “%time%” placeholder which get remaining time. This leads to configuring the plugin every month again and again. This PR fixes it with transferring exceed dates to next month. Now, the 31st day is visible in the months which have 30 days or less.